### PR TITLE
support stream shard count updates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-11-10T22:32:37Z"
-  build_hash: 18745aa8d1126566776a4748c403ae891b889e9c
+  build_date: "2022-11-16T16:56:31Z"
+  build_hash: 6976201eca44ed0edaaa732a80b74695c58f94ca
   go_version: go1.18.1
-  version: v0.20.1-7-g18745aa
-api_directory_checksum: 75e744918e54d035befd65d7a3ed9e2754d16f58
+  version: v0.20.1-10-g6976201
+api_directory_checksum: cad97d28656bba0f02310ec702f54d786b55c36b
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.113
 generator_config_info:
-  file_checksum: 12a3a90cfb88feb0f3d6bc937f385a3830bfba03
+  file_checksum: 80a65ab005815a8a4ef757169a8383e61330849e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -7,6 +7,12 @@ operations:
     resource_name: Stream
     operation_type: READ_ONE
     output_wrapper_field_path: StreamDescriptionSummary
+  UpdateShardCount:
+    resource_name: Stream
+    operation_type: UPDATE
+    override_values:
+      # This is the only accepted value for this field, and it's required...
+      ScalingType: UNIFORM_SCALING
 resources:
   Stream:
     renames:
@@ -20,6 +26,11 @@ resources:
         DeleteStream:
           input_fields:
             StreamName: Name
+        UpdateShardCount:
+          input_fields:
+            StreamName: Name
+          output_fields:
+            TargetShardCount: ShardCount
     exceptions:
       errors:
         404:

--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:ListStreams",
+                "kinesis:DeleteStream",
+                "kinesis:DescribeStreamSummary",
+                "kinesis:ListShards",
+                "kinesis:UpdateShardCount",
+                "kinesis:CreateStream",
+                "kinesis:DescribeStream"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/generator.yaml
+++ b/generator.yaml
@@ -7,6 +7,12 @@ operations:
     resource_name: Stream
     operation_type: READ_ONE
     output_wrapper_field_path: StreamDescriptionSummary
+  UpdateShardCount:
+    resource_name: Stream
+    operation_type: UPDATE
+    override_values:
+      # This is the only accepted value for this field, and it's required...
+      ScalingType: UNIFORM_SCALING
 resources:
   Stream:
     renames:
@@ -20,6 +26,11 @@ resources:
         DeleteStream:
           input_fields:
             StreamName: Name
+        UpdateShardCount:
+          input_fields:
+            StreamName: Name
+          output_fields:
+            TargetShardCount: ShardCount
     exceptions:
       errors:
         404:

--- a/test/e2e/resources/stream_simple.yaml
+++ b/test/e2e/resources/stream_simple.yaml
@@ -4,4 +4,4 @@ metadata:
   name: $STREAM_NAME
 spec:
   name: $STREAM_NAME
-  shardCount: 2
+  shardCount: $SHARD_COUNT

--- a/test/e2e/stream.py
+++ b/test/e2e/stream.py
@@ -96,7 +96,7 @@ def get(stream_name):
     """
     c = boto3.client('kinesis')
     try:
-        resp = c.describe_stream(StreamName=stream_name)
-        return resp['StreamDescription']
+        resp = c.describe_stream_summary(StreamName=stream_name)
+        return resp['StreamDescriptionSummary']
     except c.exceptions.ResourceNotFoundException:
         return None


### PR DESCRIPTION
Adds generated code and e2e tests for updating a Stream resource's shard count. Calls the separate `UpdateShardCount` Kinesis API.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
