### PR TITLE
Add Kinesis Resource Policies

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T22:54:02Z"
+  build_date: "2026-06-25T20:24:03Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.3
   version: v0.60.0
-api_directory_checksum: f0678a236e7f3f6ad06bc5de36a7678d0084aeac
+api_directory_checksum: b615c72aa8169036353b99459a2098b34205a73f
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: cbcc5b2cf42cc3de0ffa32047a95d76d5590cec6
+  file_checksum: 00b14133d2f332590ae3c2ca190bec25b269e918
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,8 @@ resources:
           output_fields:
             TargetShardCount: ShardCount
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/stream/sdk_read_one_post_set_output.go.tpl
       sdk_update_post_set_output:
@@ -52,6 +54,12 @@ resources:
         from:
           operation: AddTagsToStream
           path: Tags
+      ResourcePolicy:
+        from:
+          operation: PutResourcePolicy
+          path: Policy
+        compare:
+          is_ignored: true
       Name:
         is_primary_key: true
       # NOTE(jaypipes): It is necessary to hand-roll all these fields because

--- a/apis/v1alpha1/stream.go
+++ b/apis/v1alpha1/stream.go
@@ -33,6 +33,9 @@ type StreamSpec struct {
 	// Regex Pattern: `^[a-zA-Z0-9_.-]+$`
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
+	// Details of the resource policy. It must include the identity of the principal
+	// and the actions allowed on this resource. This is formatted as a JSON string.
+	ResourcePolicy *string `json:"resourcePolicy,omitempty"`
 	// The number of shards that the stream will use. The throughput of the stream
 	// is a function of the number of shards; more shards are required for greater
 	// provisioned throughput.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -387,6 +387,11 @@ func (in *StreamSpec) DeepCopyInto(out *StreamSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ResourcePolicy != nil {
+		in, out := &in.ResourcePolicy, &out.ResourcePolicy
+		*out = new(string)
+		**out = **in
+	}
 	if in.ShardCount != nil {
 		in, out := &in.ShardCount, &out.ShardCount
 		*out = new(int64)

--- a/config/crd/bases/kinesis.services.k8s.aws_streams.yaml
+++ b/config/crd/bases/kinesis.services.k8s.aws_streams.yaml
@@ -50,6 +50,11 @@ spec:
 
                   Regex Pattern: `^[a-zA-Z0-9_.-]+$`
                 type: string
+              resourcePolicy:
+                description: |-
+                  Details of the resource policy. It must include the identity of the principal
+                  and the actions allowed on this resource. This is formatted as a JSON string.
+                type: string
               shardCount:
                 description: |-
                   The number of shards that the stream will use. The throughput of the stream

--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -11,7 +11,10 @@
                 "kinesis:ListShards",
                 "kinesis:UpdateShardCount",
                 "kinesis:CreateStream",
-                "kinesis:DescribeStream"
+                "kinesis:DescribeStream",
+                "kinesis:PutResourcePolicy",
+                "kinesis:GetResourcePolicy",
+                "kinesis:DeleteResourcePolicy"
             ],
             "Resource": "*"
         }

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,8 @@ resources:
           output_fields:
             TargetShardCount: ShardCount
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/stream/sdk_read_one_post_set_output.go.tpl
       sdk_update_post_set_output:
@@ -52,6 +54,12 @@ resources:
         from:
           operation: AddTagsToStream
           path: Tags
+      ResourcePolicy:
+        from:
+          operation: PutResourcePolicy
+          path: Policy
+        compare:
+          is_ignored: true
       Name:
         is_primary_key: true
       # NOTE(jaypipes): It is necessary to hand-roll all these fields because

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.5
 	github.com/aws/smithy-go v1.24.2
 	github.com/go-logr/logr v1.4.3
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2
 	github.com/spf13/pflag v1.0.9
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -51,7 +52,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/helm/crds/kinesis.services.k8s.aws_streams.yaml
+++ b/helm/crds/kinesis.services.k8s.aws_streams.yaml
@@ -50,6 +50,11 @@ spec:
 
                   Regex Pattern: `^[a-zA-Z0-9_.-]+$`
                 type: string
+              resourcePolicy:
+                description: |-
+                  Details of the resource policy. It must include the identity of the principal
+                  and the actions allowed on this resource. This is formatted as a JSON string.
+                type: string
               shardCount:
                 description: |-
                   The number of shards that the stream will use. The throughput of the stream

--- a/pkg/resource/stream/delta.go
+++ b/pkg/resource/stream/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)

--- a/pkg/resource/stream/hooks_resource_policy.go
+++ b/pkg/resource/stream/hooks_resource_policy.go
@@ -1,0 +1,170 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/kinesis"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	awsiampolicy "github.com/micahhausler/aws-iam-policy/policy"
+)
+
+func (rm *resourceManager) syncResourcePolicy(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncResourcePolicy")
+	defer func() { exit(err) }()
+
+	streamARN := streamResourceARN(latest)
+	if streamARN == nil || *streamARN == "" {
+		return errors.New("stream ARN is required to sync resource policy")
+	}
+
+	if desired.ko.Spec.ResourcePolicy == nil {
+		return rm.deleteResourcePolicy(ctx, streamARN)
+	}
+	return rm.putResourcePolicy(ctx, streamARN, desired.ko.Spec.ResourcePolicy)
+}
+
+func (rm *resourceManager) putResourcePolicy(
+	ctx context.Context,
+	streamARN *string,
+	policy *string,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.putResourcePolicy")
+	defer func() { exit(err) }()
+
+	_, err = rm.sdkapi.PutResourcePolicy(
+		ctx,
+		&svcsdk.PutResourcePolicyInput{
+			ResourceARN: streamARN,
+			Policy:      policy,
+		},
+	)
+	rm.metrics.RecordAPICall("UPDATE", "PutResourcePolicy", err)
+	return err
+}
+
+func (rm *resourceManager) deleteResourcePolicy(
+	ctx context.Context,
+	streamARN *string,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.deleteResourcePolicy")
+	defer func() { exit(err) }()
+
+	_, err = rm.sdkapi.DeleteResourcePolicy(
+		ctx,
+		&svcsdk.DeleteResourcePolicyInput{
+			ResourceARN: streamARN,
+		},
+	)
+	rm.metrics.RecordAPICall("DELETE", "DeleteResourcePolicy", err)
+	if err != nil {
+		var notFound *svcsdktypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			// Policy already doesn't exist, this is a success case.
+			return nil
+		}
+	}
+	return err
+}
+
+func (rm *resourceManager) getResourcePolicy(
+	ctx context.Context,
+	streamARN *string,
+) (policy *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getResourcePolicy")
+	defer func() { exit(err) }()
+
+	if streamARN == nil || *streamARN == "" {
+		return nil, errors.New("stream ARN is required to get resource policy")
+	}
+
+	res, err := rm.sdkapi.GetResourcePolicy(
+		ctx,
+		&svcsdk.GetResourcePolicyInput{
+			ResourceARN: streamARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "GetResourcePolicy", err)
+	if err != nil {
+		var notFound *svcsdktypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return res.Policy, nil
+}
+
+func streamResourceARN(r *resource) *string {
+	if r == nil || r.ko.Status.ACKResourceMetadata == nil {
+		return nil
+	}
+	return (*string)(r.ko.Status.ACKResourceMetadata.ARN)
+}
+
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	compareResourcePolicyDocument(delta, a, b)
+}
+
+// compareResourcePolicyDocument is a custom comparison function for the
+// ResourcePolicy document. A dedicated function is needed to handle the
+// variability in the shapes of JSON objects representing IAM policies
+// (statements, actions, etc.), since Kinesis returns a normalized document that
+// would otherwise show as a perpetual diff.
+//
+// Copied from the DynamoDB controller, which copied it from the IAM controller:
+// https://github.com/aws-controllers-k8s/iam-controller/blob/main/pkg/resource/role/hooks.go
+func compareResourcePolicyDocument(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	// One side has a policy and the other doesn't - they differ.
+	if ackcompare.HasNilDifference(a.ko.Spec.ResourcePolicy, b.ko.Spec.ResourcePolicy) {
+		delta.Add("Spec.ResourcePolicy", a.ko.Spec.ResourcePolicy, b.ko.Spec.ResourcePolicy)
+		return
+	}
+	// Both nil - no difference.
+	if a.ko.Spec.ResourcePolicy == nil && b.ko.Spec.ResourcePolicy == nil {
+		return
+	}
+
+	// Both non-nil: compare the parsed policy documents semantically.
+	var policyDocumentA awsiampolicy.Policy
+	_ = json.Unmarshal([]byte(*a.ko.Spec.ResourcePolicy), &policyDocumentA)
+	var policyDocumentB awsiampolicy.Policy
+	_ = json.Unmarshal([]byte(*b.ko.Spec.ResourcePolicy), &policyDocumentB)
+
+	if !reflect.DeepEqual(policyDocumentA, policyDocumentB) {
+		delta.Add("Spec.ResourcePolicy", a.ko.Spec.ResourcePolicy, b.ko.Spec.ResourcePolicy)
+	}
+}

--- a/pkg/resource/stream/hooks_resource_policy_test.go
+++ b/pkg/resource/stream/hooks_resource_policy_test.go
@@ -1,0 +1,173 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stream
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws-controllers-k8s/kinesis-controller/apis/v1alpha1"
+	compare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+func streamWithPolicy(policy *string) *resource {
+	return &resource{
+		ko: &v1alpha1.Stream{
+			Spec: v1alpha1.StreamSpec{
+				ResourcePolicy: policy,
+			},
+		},
+	}
+}
+
+func Test_compareResourcePolicyDocument(t *testing.T) {
+	type args struct {
+		a *resource
+		b *resource
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantDifferent bool
+	}{
+		{
+			name: "both policies are nil",
+			args: args{
+				a: streamWithPolicy(nil),
+				b: streamWithPolicy(nil),
+			},
+			wantDifferent: false,
+		},
+		{
+			name: "desired policy is set, latest policy is nil",
+			args: args{
+				a: streamWithPolicy(aws.String(`{"Version": "2012-10-17"}`)),
+				b: streamWithPolicy(nil),
+			},
+			wantDifferent: true,
+		},
+		{
+			name: "identical policy documents",
+			args: args{
+				a: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords", "kinesis:GetShardIterator"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+				b: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords", "kinesis:GetShardIterator"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+			},
+			wantDifferent: false,
+		},
+		{
+			name: "same policy content with different whitespace formatting",
+			args: args{
+				a: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords", "kinesis:GetShardIterator"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+				b: streamWithPolicy(aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":["kinesis:GetRecords","kinesis:GetShardIterator"],"Resource":"arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"}]}`)),
+			},
+			wantDifferent: false,
+		},
+		{
+			name: "different effect in statement",
+			args: args{
+				a: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+				b: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Deny",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+			},
+			wantDifferent: true,
+		},
+		{
+			name: "different actions in statement",
+			args: args{
+				a: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:GetRecords"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+				b: streamWithPolicy(aws.String(`{
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+							"Action": ["kinesis:PutRecord"],
+							"Resource": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream"
+						}
+					]
+				}`)),
+			},
+			wantDifferent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delta := &compare.Delta{}
+			compareResourcePolicyDocument(delta, tt.args.a, tt.args.b)
+			if got := delta.DifferentAt("Spec.ResourcePolicy"); got != tt.wantDifferent {
+				t.Errorf("compareResourcePolicyDocument() difference = %v, want %v", got, tt.wantDifferent)
+			}
+		})
+	}
+}

--- a/pkg/resource/stream/sdk.go
+++ b/pkg/resource/stream/sdk.go
@@ -178,6 +178,15 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
+	// Read the stream's resource-based policy (if any) into the spec so drift
+	// against the desired policy can be detected.
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+		ko.Spec.ResourcePolicy, err = rm.getResourcePolicy(ctx, (*string)(ko.Status.ACKResourceMetadata.ARN))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if !isStreamActive(r.ko.Status.StreamStatus) {
 		return &resource{ko}, ackrequeue.Needed(fmt.Errorf("resource is not active"))
 	}
@@ -240,7 +249,9 @@ func (rm *resourceManager) sdkCreate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
-	if ko.Spec.Tags != nil {
+	// Tags and the resource policy are applied on a follow-up reconcile, so mark
+	// the resource as not-yet-synced to trigger one.
+	if ko.Spec.Tags != nil || ko.Spec.ResourcePolicy != nil {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}
 	return &resource{ko}, nil
@@ -299,7 +310,13 @@ func (rm *resourceManager) sdkUpdate(
 			return nil, err
 		}
 	}
-	if !delta.DifferentExcept("Spec.Tags") {
+	// The resource-based policy is managed out-of-band of UpdateShardCount.
+	if delta.DifferentAt("Spec.ResourcePolicy") {
+		if err := rm.syncResourcePolicy(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags", "Spec.ResourcePolicy") {
 		return desired, nil
 	}
 	input, err := rm.newUpdateRequestPayload(ctx, desired, delta)

--- a/templates/hooks/stream/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/stream/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,5 @@
-	if ko.Spec.Tags != nil {
+	// Tags and the resource policy are applied on a follow-up reconcile, so mark
+	// the resource as not-yet-synced to trigger one.
+	if ko.Spec.Tags != nil || ko.Spec.ResourcePolicy != nil {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}

--- a/templates/hooks/stream/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/stream/sdk_read_one_post_set_output.go.tpl
@@ -5,6 +5,15 @@
         return nil, err
     }
 
+    // Read the stream's resource-based policy (if any) into the spec so drift
+    // against the desired policy can be detected.
+    if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+        ko.Spec.ResourcePolicy, err = rm.getResourcePolicy(ctx, (*string)(ko.Status.ACKResourceMetadata.ARN))
+        if err != nil {
+            return nil, err
+        }
+    }
+
 	if !isStreamActive(r.ko.Status.StreamStatus) {
 		return &resource{ko}, ackrequeue.Needed(fmt.Errorf("resource is not active"))
 	}

--- a/templates/hooks/stream/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/stream/sdk_update_pre_build_request.go.tpl
@@ -8,6 +8,12 @@
 			return nil, err
 		}
 	}
-	if !delta.DifferentExcept("Spec.Tags") {
+	// The resource-based policy is managed out-of-band of UpdateShardCount.
+	if delta.DifferentAt("Spec.ResourcePolicy") {
+		if err := rm.syncResourcePolicy(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags", "Spec.ResourcePolicy") {
 		return desired, nil
 	}

--- a/test/e2e/resources/stream_resource_policy.yaml
+++ b/test/e2e/resources/stream_resource_policy.yaml
@@ -1,0 +1,9 @@
+# Stream used to test resource-based policy functionality
+apiVersion: kinesis.services.k8s.aws/v1alpha1
+kind: Stream
+metadata:
+  name: $STREAM_NAME
+spec:
+  name: $STREAM_NAME
+  shardCount: $SHARD_COUNT
+  resourcePolicy: '$RESOURCE_POLICY'

--- a/test/e2e/stream.py
+++ b/test/e2e/stream.py
@@ -112,3 +112,19 @@ def get_tags(stream_name):
         return resp['Tags']
     except c.exceptions.ResourceNotFoundException:
         return None
+
+
+def get_resource_policy(stream_arn):
+    """Returns the resource-based policy document (a JSON string) attached to
+    the stream with the supplied ARN.
+
+    If no policy is attached (or the stream does not exist), returns None.
+    """
+    c = boto3.client('kinesis')
+    try:
+        resp = c.get_resource_policy(ResourceARN=stream_arn)
+        if resp.get('Policy'):
+            return resp['Policy']
+        return None
+    except c.exceptions.ResourceNotFoundException:
+        return None

--- a/test/e2e/tests/test_stream.py
+++ b/test/e2e/tests/test_stream.py
@@ -13,11 +13,13 @@
 
 """Integration tests for the Kinesis Stream resource"""
 
+import json
 import logging
 import time
 
 import pytest
 
+from acktest.aws.identity import get_account_id, get_region
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
@@ -122,6 +124,98 @@ class TestStream:
             expected=user_tags,
             actual=response_tags,
         )
+
+        k8s.delete_custom_resource(ref)
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        stream.wait_until_deleted(stream_name)
+
+    def test_resource_policy(self):
+        stream_name = random_suffix_name("my-policy-stream", 24)
+        shard_count = "1"
+        account_id = get_account_id()
+        region = get_region()
+        stream_arn = f"arn:aws:kinesis:{region}:{account_id}:stream/{stream_name}"
+
+        resource_policy = {
+            "Version": "2012-10-17",
+            "Id": "ack-stream-with-policy",
+            "Statement": [
+                {
+                    "Sid": "EnableResourcePolicyOnStream",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": f"arn:aws:iam::{account_id}:root"
+                    },
+                    "Action": [
+                        "kinesis:GetRecords",
+                        "kinesis:GetShardIterator",
+                        "kinesis:DescribeStreamSummary",
+                        "kinesis:ListShards",
+                    ],
+                    "Resource": stream_arn,
+                }
+            ],
+        }
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements['STREAM_NAME'] = stream_name
+        replacements['SHARD_COUNT'] = shard_count
+        replacements['RESOURCE_POLICY'] = json.dumps(resource_policy)
+
+        resource_data = load_kinesis_resource(
+            "stream_resource_policy",
+            additional_replacements=replacements,
+        )
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            stream_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        k8s.wait_resource_consumed_by_controller(ref)
+
+        stream.wait_until_exists(stream_name)
+
+        # The policy is attached out-of-band after the stream becomes active, so
+        # wait for the controller to report the resource as synced.
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        # The stream ARN is required to query the resource policy.
+        cr = k8s.get_resource(ref)
+        stream_arn = cr["status"]["ackResourceMetadata"]["arn"]
+
+        policy = stream.get_resource_policy(stream_arn)
+        assert policy is not None
+        assert "ack-stream-with-policy" in policy
+
+        # Update the policy and confirm it is applied.
+        resource_policy['Id'] = 'updated-stream-policy'
+        updates = {
+            "spec": {
+                "resourcePolicy": json.dumps(resource_policy),
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        policy = stream.get_resource_policy(stream_arn)
+        assert policy is not None
+        assert "updated-stream-policy" in policy
+
+        # Clearing the policy should delete it from the stream.
+        updates = {
+            "spec": {
+                "resourcePolicy": None,
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        assert stream.get_resource_policy(stream_arn) is None
 
         k8s.delete_custom_resource(ref)
 


### PR DESCRIPTION
## What?
Adds support for Kinesis Resource Policies

## How?
This follows the same approach as the DynamoDB controller uses for Resource Policies and is almost identical.

A `resourcePolicy` attribute is added to the `Stream` CRD and it requires very similar sync mechanisms as DynamoDB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
